### PR TITLE
chrome.storage.local.get to window.localStorage for refresh property

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -43,6 +43,10 @@ function favicon(url) {
   return (scheme ? scheme + '://' : '') + host.split('/').shift() + '/favicon.ico';
 }
 
+function getAlarmRefreshMinute() {
+  return typeof localStorage.refresh !== 'undefined' ?
+    parseInt(localStorage.refresh) : 5;
+}
 function onStartup() {
   console.debug('background.onStartup...');
 
@@ -55,9 +59,7 @@ function onStartup() {
       updateIcon(items.changes);
     });
   fetchChanges();
-  chrome.storage.local.get('refresh', function(items) {
-      chrome.alarms.create('refresh', {periodInMinutes: items.refresh});
-    });
+  chrome.alarms.create('refresh', {periodInMinutes: getAlarmRefreshMinute()});
   chrome.browserAction.setBadgeBackgroundColor({color: '#000'});
 }
 


### PR DESCRIPTION
From chrome extension,  the value saved with `window.localStorage` can't be loaded with `chrome.storage.local.get`.

Fixes below error.

![image](https://cloud.githubusercontent.com/assets/756988/19410248/cd737fd4-9321-11e6-80e3-ce5a7fe41cc4.png)
