### PR TITLE
Add codereview & verified TR when there exist.

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -74,8 +74,10 @@ function initUI(items) {
     tr.appendChild(link);
     tr.appendChild(message);
     tr.appendChild(getDelta(change));
-    tr.appendChild(getCodeReview(change));
-    tr.appendChild(getVerified(change));
+    if (typeof change.labels != 'undefined') {
+      tr.appendChild(getCodeReview(change));
+      tr.appendChild(getVerified(change));
+    }
 
     if (change.read) {
       tr.className = 'read';


### PR DESCRIPTION
`Code-Review` and `Verified` exist only when user's query includes `&o=LABELS`.  that means normally `Code-Review` and `Verfied` don't exist. there could be an error.

![image](https://cloud.githubusercontent.com/assets/756988/19417452/6ba602f0-93e8-11e6-9b0b-7537a6975dd7.png)
